### PR TITLE
Release v1.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     ruby-full \
     rlwrap \
     build-essential \
-    socat \
     # Cleanup
     && DEBIAN_FRONTEND=noninteractive apt-get clean &&\
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -182,6 +181,8 @@ WORKDIR /var/www
 
 # Default SSH key name
 ENV SSH_KEY_NAME id_rsa
+# ssh-agent proxy socket (requires blinkreaction/ssh-agent)
+ENV SSH_AUTH_SOCK /.ssh-agent/proxy-socket
 
 # Starter script
 ENTRYPOINT ["/opt/startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,12 +82,10 @@ RUN mkdir -p /var/www/docroot && \
     sed -i '/max_execution_time = /c max_execution_time = 600' /etc/php5/cli/php.ini && \
     sed -i '/error_log = php_errors.log/c error_log = \/dev\/stdout' /etc/php5/cli/php.ini && \
     sed -i '/;sendmail_path/c sendmail_path = /bin/true' /etc/php5/cli/php.ini && \
-    rm  /etc/php5/mods-available/xdebug.ini && \
     # PHP module settings
     echo 'opcache.memory_consumption=128' >> /etc/php5/mods-available/opcache.ini
 
-# Make xdebug available for php-fpm only
-COPY config/php5/xdebug.ini /etc/php5/fpm/conf.d/xdebug.ini
+COPY config/php5/xdebug.ini /etc/php5/mods-available/xdebug.ini
 
 # Adding NodeJS repo (for up-to-date versions)
 # This is a stripped down version of the official nodejs install script (https://deb.nodesource.com/setup_4.x)

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,10 +82,12 @@ RUN mkdir -p /var/www/docroot && \
     sed -i '/max_execution_time = /c max_execution_time = 600' /etc/php5/cli/php.ini && \
     sed -i '/error_log = php_errors.log/c error_log = \/dev\/stdout' /etc/php5/cli/php.ini && \
     sed -i '/;sendmail_path/c sendmail_path = /bin/true' /etc/php5/cli/php.ini && \
+    rm  /etc/php5/mods-available/xdebug.ini && \
     # PHP module settings
     echo 'opcache.memory_consumption=128' >> /etc/php5/mods-available/opcache.ini
 
-COPY config/php5/xdebug.ini /etc/php5/mods-available/xdebug.ini
+# Make xdebug available for php-fpm only
+COPY config/php5/xdebug.ini /etc/php5/fpm/conf.d/xdebug.ini
 
 # Adding NodeJS repo (for up-to-date versions)
 # This is a stripped down version of the official nodejs install script (https://deb.nodesource.com/setup_4.x)

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,10 @@ RUN mkdir /var/run/sshd & \
     echo "export VISIBLE=now" >> /etc/profile
 ENV NOTVISIBLE "in users profile"
 
+# Include blackfire.io repo
+RUN wget -O - https://packagecloud.io/gpg.key | sudo apt-key add - && \
+    echo "deb http://packages.blackfire.io/debian any main" | sudo tee /etc/apt/sources.list.d/blackfire.list
+
 # PHP packages
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y --force-yes --no-install-recommends install \
@@ -53,6 +57,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     php5-xdebug \
     php5-ssh2 \
     php5-gnupg \
+    blackfire-php \
     # Cleanup
     && DEBIAN_FRONTEND=noninteractive apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -84,6 +89,7 @@ RUN mkdir -p /var/www/docroot && \
     sed -i '/;sendmail_path/c sendmail_path = /bin/true' /etc/php5/cli/php.ini && \
     # PHP module settings
     echo 'opcache.memory_consumption=128' >> /etc/php5/mods-available/opcache.ini && \
+    sed -i '/blackfire.agent_socket = /c blackfire.agent_socket = tcp://blackfire:8707' /etc/php5/mods-available/blackfire.ini && \
     # Disable xdebug by default. We will enabled it at startup (see startup.sh)
     php5dismod xdebug
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,8 +97,8 @@ RUN gem install bundler
 # Home directory for bundle installs
 ENV BUNDLE_PATH .bundler
 
-ENV DRUSH_VERSION 8.0.1
-ENV DRUPAL_CONSOLE_VERSION 0.10.1
+ENV DRUSH_VERSION 8.0.5
+ENV DRUPAL_CONSOLE_VERSION 1.0.0-alpha1
 RUN \
     # Composer
     curl -sSL https://getcomposer.org/installer | php && \
@@ -115,8 +115,8 @@ ENV PATH /home/docker/.composer/vendor/bin:$PATH
 USER docker
 
 # Install nvm and a default node version
-ENV NVM_VERSION 0.30.1
-ENV NODE_VERSION 4.2.4
+ENV NVM_VERSION 0.31.0
+ENV NODE_VERSION 4.4.3
 ENV NVM_DIR /home/docker/.nvm
 RUN \
     curl -sSL https://raw.githubusercontent.com/creationix/nvm/v${NVM_VERSION}/install.sh | bash && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -135,8 +135,8 @@ RUN \
     echo "alias drush7='/home/docker/drush7/vendor/bin/drush'" >> /home/docker/.bashrc && \
     echo "alias drush8='/usr/local/bin/drush'" >> /home/docker/.bashrc && \
     # Drush modules
-    drush dl registry_rebuild-7.x-2.2 && \
-    drush dl coder --destination=/home/docker/.drush && \
+    drush dl registry_rebuild --default-major=7 --destination=/home/docker/.drush && \
+    drush dl coder --default-major=8 --destination=/home/docker/.drush && \
     drush cc drush && \
     # Drupal Coder w/ a matching version of PHP_CodeSniffer
     composer global require drupal/coder && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,8 +83,12 @@ RUN mkdir -p /var/www/docroot && \
     sed -i '/error_log = php_errors.log/c error_log = \/dev\/stdout' /etc/php5/cli/php.ini && \
     sed -i '/;sendmail_path/c sendmail_path = /bin/true' /etc/php5/cli/php.ini && \
     # PHP module settings
-    echo 'opcache.memory_consumption=128' >> /etc/php5/mods-available/opcache.ini
+    echo 'opcache.memory_consumption=128' >> /etc/php5/mods-available/opcache.ini && \
+    # Disable xdebug by default. We will enabled it at startup (see startup.sh)
+    php5dismod xdebug
 
+# xdebug settings
+ENV XDEBUG_ENABLED 0
 COPY config/php5/xdebug.ini /etc/php5/mods-available/xdebug.ini
 
 # Adding NodeJS repo (for up-to-date versions)

--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -8,3 +8,10 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:sshd]
+command=/usr/sbin/sshd -D
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/startup.sh
+++ b/startup.sh
@@ -57,5 +57,19 @@ copy_dot_drush '/.home-b2d' # boot2docker (docker-compose)
 # Reset home directory ownership
 sudo chown $(id -u):$(id -g) -R ~
 
+# Enable/disable xdebug
+php5query -s fpm -m xdebug 1>/dev/null; xdebug_status=$?
+if [ $XDEBUG_ENABLED -eq 1 ]; then
+  if [ $xdebug_status -ne 0 ]; then
+    echo "Enabling xdebug (fpm)..."
+    sudo php5enmod -s fpm xdebug
+  fi
+else
+  if [ $xdebug_status -eq 0 ]; then
+    echo "Disabling xdebug (fpm)..."
+    sudo php5dismod -s fpm xdebug
+  fi
+fi
+
 # Execute passed CMD arguments
 exec "$@"

--- a/startup.sh
+++ b/startup.sh
@@ -59,11 +59,6 @@ copy_dot_drush '/.home' # Generic
 copy_dot_drush '/.home-linux' # Linux (docker-compose)
 copy_dot_drush '/.home-b2d' # boot2docker (docker-compose)
 
-# Create proxy-socket for ssh-agent
-sudo rm ~/.ssh/socket
-sudo socat UNIX-LISTEN:~/.ssh/socket,fork UNIX-CONNECT:/.ssh-agent/socket &
-sudo chown $(id -u) ~/.ssh/socket
-
 # Reset home directory ownership
 sudo chown $(id -u):$(id -g) -R ~
 

--- a/startup.sh
+++ b/startup.sh
@@ -68,16 +68,16 @@ sudo chown $(id -u) ~/.ssh/socket
 sudo chown $(id -u):$(id -g) -R ~
 
 # Enable/disable xdebug
-php5query -s fpm -m xdebug 1>/dev/null; xdebug_status=$?
+php5query -m xdebug 1>/dev/null; xdebug_status=$?
 if [ $XDEBUG_ENABLED -eq 1 ]; then
   if [ $xdebug_status -ne 0 ]; then
-    echo "Enabling xdebug (fpm)..."
-    sudo php5enmod -s fpm xdebug
+    echo "Enabling xdebug..."
+    sudo php5enmod xdebug
   fi
 else
   if [ $xdebug_status -eq 0 ]; then
-    echo "Disabling xdebug (fpm)..."
-    sudo php5dismod -s fpm xdebug
+    echo "Disabling xdebug..."
+    sudo php5dismod xdebug
   fi
 fi
 


### PR DESCRIPTION
- Added SSH daemon
  - This allows using php and other developer tools in the `cli` container remotely (e.g. with PHPStorm)
  - Usersname and password - `docker:docker`
- xdebug
  - xdebug is now disabled by default
  - control xdebug via XDEBUG_ENABLED environment variable (e.g. `XDEBUG_ENABLED=1`)
- Added blackfire extension
- Added support for [ssh-agent](https://github.com/blinkreaction/docker-ssh-agent)
- Make sure coder version 8.x is used
